### PR TITLE
Replace GitLab remnant with useful text

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting.md
+++ b/.github/ISSUE_TEMPLATE/meeting.md
@@ -19,7 +19,7 @@ assignees: ''
 - Host: @somebody
 - Notes: @somebody-else
 
-/zoom https://tum-conf.zoom.us/j/66092257079?pwd=ZDNIV3JJb1VOK1FVR1ZIMkFJc2hJQT09
+Link to Zoom meeting: https://tum-conf.zoom.us/j/66092257079?pwd=ZDNIV3JJb1VOK1FVR1ZIMkFJc2hJQT09
 
 <!-- List of participants -->
 


### PR DESCRIPTION
The "/zoom" keyword was useful on GitLab, but is not recognized on GitHub. Let's write a useful text instead.